### PR TITLE
SWQA-2164 Make summary screen more responsive for small devices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ docs/.vitepress/dist
 docs/.vitepress/cache
 .DS_Store
 Thumbs.db
+
+# vscode
+.vscode

--- a/platforms/html5/src/styles/summary.scss
+++ b/platforms/html5/src/styles/summary.scss
@@ -1,3 +1,6 @@
+$swGold: #F90;
+$smallScreenHeight: 530px;
+
 .swag-summary {
   position: fixed;
   top: 0;
@@ -14,9 +17,11 @@
 }
 
 .swag-summary__inner {
+  width: 100%;
   max-width: 600px;
   padding: 1rem;
   margin: auto;
+  box-sizing: border-box;
 
   h4 {
     font-size: 125%;
@@ -29,8 +34,12 @@
   }
 }
 
-.swag-summary__inner > * {
-  margin: 1rem 0;
+.swag-summary__inner > * + * {
+  margin-top: 1rem;
+
+  @media screen and (min-height: ($smallScreenHeight + 40px)) {
+    margin-top: 1.5rem;
+  }
 }
 
 .swag-summary__inner > header {
@@ -39,16 +48,15 @@
   justify-content: center;
   margin-bottom: 0;
   flex-direction: column;
-  
-  // @media (min-width: 768px) {
-  //   flex-direction: row;
-  // }
+
+  > * + * {
+    margin-top: 1rem;
+  }
 }
 
 .swag-summary__title {
   font-size: 1rem !important;
   text-align: center;
-  margin-bottom: 0.5rem;
 }
 
 .swag-summary__preview-container {
@@ -60,12 +68,6 @@
 .swag-summary__preview {
   position: relative;
   margin-top: 0;
-  margin-bottom: 0.5rem;
-  
-  // @media (min-width: 768px) {
-  //   margin-right: 0.5rem;
-  //   margin-bottom: 0;
-  // }
 }
 
 .swag-summary__stats {
@@ -76,18 +78,32 @@
   flex-wrap: wrap;
   align-items: center;
   justify-content: center;
+  width: 100%;
+  max-width: 480px;
 
   li {
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    margin: 0.5rem 1rem;
-    width: calc(33% - 2rem);
+    width: calc(33% - 1rem);
+    margin-left: 1rem;
+
+    &:nth-child(3n - 2){
+      margin-left: 0;
+    }
+
+    &:nth-child(n + 4) {
+      margin-top: 1rem;
+    }
 
     strong {
       font-size: 2rem !important;
       font-weight: bold !important;
+
+      @media screen and (max-height: ($smallScreenHeight + 20px)) {
+        font-size: 1.2rem !important;
+      }
     }
 
     span {
@@ -101,15 +117,6 @@
       }
     }
   }
-
-  // @media (min-width: 768px) {
-  //   flex-direction: column;
-  //   max-height: 215px;
-
-  //   li {
-  //     width: auto;
-  //   }
-  // }
 }
 
 .swag-summary__btn {
@@ -120,8 +127,10 @@
   appearance: none;
   background: #000;
   color: #fff;
+  background: $swGold;
   font-weight: 500;
-  min-width: 150px;
+  font-size: 0.75rem;
+  flex: 1 1 0;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -134,15 +143,10 @@
   }
 }
 
-.swag-summary__btn {
-  background: #F90;
-  color: #FFF;
-}
-
 .swag-summary__btn.--outline {
   background: transparent;
-  box-shadow: 0 0 0 1px #F90 inset;
-  color: #F90;
+  box-shadow: 0 0 0 1px $swGold inset;
+  color: $swGold;
 }
 
 .swag-summary__btn.--noMarginTop {
@@ -152,20 +156,25 @@
 .swag-summary__related-games {
   display: flex;
   flex-direction: column;
-  margin: 1rem 0;
-  padding: 0;
   align-items: center;
+  padding: 0;
+  margin-bottom: 0;
 
   li {
+    box-sizing: border-box;
     padding: 0 0.75rem;
-    margin: 0.5rem;
     border-radius: 10px;
     background-color: #D9D9D9;
     display: flex;
     align-items: center;
     cursor: pointer;
-    width: 225px;
+    width: 100%;
+    max-width: 320px;
     height: 67px;
+
+    + li {
+      margin-top: 1rem;
+    }
   }
 
   img {
@@ -180,22 +189,35 @@
 .swag-summary__promo-links {
   display: flex;
   flex-direction: column;
-  margin: 1rem 0;
-  padding: 0;
   align-items: center;
+  padding: 0;
+  margin-bottom: 0;
 
   li {
+    box-sizing: border-box;
     padding: 0 1rem;
-    margin: 0.5rem;
     border-radius: 14px;
     background-color: #D9D9D9;
-    font-size: 12px;
+    font-size: 0.75rem;
     color: #fff;
     display: flex;
     align-items: center;
     cursor: pointer;
-    width: 289px;
+    width: 100%;
+    max-width: 320px;
     height: 67px;
+
+    + li {
+      margin-top: 1rem;
+    }
+  }
+
+  // hide everything except the first button on small displays
+  @media screen and (max-height: $smallScreenHeight) {
+    li:not(:first-child) {
+      display: none;
+      margin: 0;
+    }
   }
 
   img {
@@ -211,12 +233,10 @@
   display: inline-flex;
   margin-left: auto;
   margin-right: auto;
+  width: 100%;
+  max-width: 320px;
 
-  > * {
-    margin: 0 0.75rem;
-  }
-
-  + .swag-summary__promo-links {
-    margin-top: 0;
+  > * + * {
+    margin-left: 1rem;
   }
 }

--- a/platforms/html5/src/summary.tsx
+++ b/platforms/html5/src/summary.tsx
@@ -37,7 +37,7 @@ function ShareStatsComponent (props: ShareStatsProps) {
       {
         copying 
           ? <>Copied!</> 
-          : <>Share Stats <img src={shareIcon} alt='icon' aria-hidden /></>
+          : <>Share<img src={shareIcon} alt='icon' aria-hidden /></>
       }
     </button>
   );
@@ -60,7 +60,7 @@ function ReplayComponent (props: ReplayProps) {
       className='swag-summary__btn --outline --noMarginTop'
       onClick={onReplay}
     >
-      Replay <img src={replayIcon} alt='icon' aria-hidden />
+      Replay<img src={replayIcon} alt='icon' aria-hidden />
     </button>
   );
 }

--- a/platforms/html5/vite.config.ts
+++ b/platforms/html5/vite.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
     'process.env': process.env
   },
   server: {
+    host: 'local.shockwave.com',
     port: 8888
   },
   preview: {


### PR DESCRIPTION
Added responsive scaling to the summary screen. We now hide the second promo button and make the summary stats font smaller for restrictive devices, and restore them as the iframe gets larger. Also fixed some issues where elements were overflowing the container on the right hand side.

As housekeeping, also added a launch config option to the Vite config to specify the host address for local development on later versions of node.