### PR TITLE
Add local timezone to SWAG requests

### DIFF
--- a/platforms/html5/.env
+++ b/platforms/html5/.env
@@ -1,2 +1,4 @@
 VITE_API_URL=https://swag-services.shockwave.com
 VITE_API_STAGING_URL=https://swag-services-staging.shockwave.com
+VITE_API_DEVELOPMENT_URL=https://local.shockwave.com:8888
+VITE_DEFAULT_TIMEZONE=America/Los_Angeles

--- a/platforms/html5/src/config.ts
+++ b/platforms/html5/src/config.ts
@@ -2,7 +2,7 @@ import { version } from '../package.json';
 
 function getApiRoot () {
   if (window.location.href.includes('env=staging')) {
-    if(import.meta.env.MODE === 'development') {
+    if (import.meta.env.MODE === 'development') {
       return import.meta.env.VITE_API_DEVELOPMENT_URL;
     } else {
       return import.meta.env.VITE_API_STAGING_URL;

--- a/platforms/html5/src/config.ts
+++ b/platforms/html5/src/config.ts
@@ -1,11 +1,12 @@
 import { version } from '../package.json';
 
 function getApiRoot () {
-  if (
-    window.location.href.includes('env=staging') && 
-    (import.meta.env.MODE === 'staging' || import.meta.env.MODE === 'development')
-  ) {
-    return import.meta.env.VITE_API_STAGING_URL;
+  if (window.location.href.includes('env=staging')) {
+    if(import.meta.env.MODE === 'development') {
+      return import.meta.env.VITE_API_DEVELOPMENT_URL;
+    } else {
+      return import.meta.env.VITE_API_STAGING_URL;
+    }
   } else {
     return import.meta.env.VITE_API_URL;
   }

--- a/platforms/html5/src/data.ts
+++ b/platforms/html5/src/data.ts
@@ -130,6 +130,7 @@ const methods = Emitter({
       const rootUrl = options.apiRoot || config.themes[ session.theme! ].apiRoot;
       const params = methods.buildUrlParamString(options.params);
       xhr.open('GET', encodeURI(rootUrl + options.method + params));
+      xhr.setRequestHeader('x-local-tz', utils.getTimeZone());
       if (session.jwt) {
         xhr.setRequestHeader('x-member-token', session.jwt);
       } else {
@@ -168,6 +169,7 @@ const methods = Emitter({
       const contentType = options.contentType || 'application/json;charset=UTF-8';
       xhr.open('POST', encodeURI(rootUrl + options.method), true);
       xhr.setRequestHeader('Content-Type', contentType);
+      xhr.setRequestHeader('x-local-tz', utils.getTimeZone());
       if (session.jwt) {
         xhr.setRequestHeader('x-member-token', session.jwt);
       } else {

--- a/platforms/html5/src/utils.ts
+++ b/platforms/html5/src/utils.ts
@@ -89,9 +89,11 @@ const methods = {
   },
 
   getTimeZone: function (): string {
-    if(typeof window === 'undefined' || 
-       typeof Intl.DateTimeFormat !== 'function' || 
-       typeof Intl.DateTimeFormat().resolvedOptions !== 'function') {
+    if (
+      typeof window === 'undefined' || 
+      typeof Intl?.DateTimeFormat !== 'function' || 
+      typeof Intl?.DateTimeFormat().resolvedOptions !== 'function'
+    ) {
       return import.meta.env.VITE_DEFAULT_TIMEZONE;
     }
 

--- a/platforms/html5/src/utils.ts
+++ b/platforms/html5/src/utils.ts
@@ -86,7 +86,18 @@ const methods = {
       return 'standalone';
     }
     return 'embed';
-  }
+  },
+
+  getTimeZone: function (): string {
+    if(typeof window === 'undefined' || 
+       typeof Intl.DateTimeFormat !== 'function' || 
+       typeof Intl.DateTimeFormat().resolvedOptions !== 'function') {
+      return import.meta.env.VITE_DEFAULT_TIMEZONE;
+    }
+
+    return Intl.DateTimeFormat().resolvedOptions()?.timeZone ?? import.meta.env.VITE_DEFAULT_TIMEZONE;
+  },
+
 };
 
 export default methods;

--- a/platforms/html5/vite.config.ts
+++ b/platforms/html5/vite.config.ts
@@ -21,10 +21,10 @@ export default defineConfig({
   },
   server: {
     host: 'local.shockwave.com',
-    port: 8888
+    port: process.env.PORT || 8888
   },
   preview: {
-    port: 8888
+    port: process.env.PORT || 8888
   },
   build: {
     // sourcemap: false,


### PR DESCRIPTION
Adding a new header (`x-local-tz`) to SWAG requests to support efforts to localize daily times to users. Added some extra config to allow running the local bundle alongside swag-api on local development, so port number can now be given as an environment variable, and local api URL can be selected with `MODE=development` as an env variable.